### PR TITLE
Refactored code parser

### DIFF
--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETClass.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETClass.cs
@@ -7,14 +7,14 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
 {
     public class CaDETClass
     {
-        public string Name { get; set; }
-        public string FullName { get; set; }
-        public string SourceCode { get; set; }
-        public CaDETClass Parent { get; set; }
-        public List<CaDETModifier> Modifiers { get; set; }
-        public List<CaDETMember> Members { get; set; }
-        public List<CaDETField> Fields { get; set; }
-        public CaDETClassMetrics Metrics { get; set; }
+        public string Name { get; internal set; }
+        public string FullName { get; internal set; }
+        public string SourceCode { get; internal set; }
+        public CaDETClass Parent { get; internal set; }
+        public List<CaDETModifier> Modifiers { get; internal set; }
+        public List<CaDETMember> Members { get; internal set; }
+        public List<CaDETField> Fields { get; internal set; }
+        public CaDETClassMetrics Metrics { get; internal set; }
 
         public CaDETMember FindMember(string name)
         {
@@ -28,7 +28,7 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
 
         public bool IsDataClass()
         {
-            double numOfAccessors = Members.Count(m => m.IsSimpleAccessor());
+            double numOfAccessors = Members.Count(m => m.IsFieldDefiningAccessor());
             double numOfConstructors = Members.Count(m => m.Type.Equals(CaDETMemberType.Constructor));
             double numOfObjectOverrides = CountToStringEqualsHashCode();
             //TODO: Create a more elegant solution for thresholds.

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETClass.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETClass.cs
@@ -12,29 +12,34 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
         public string SourceCode { get; set; }
         public CaDETClass Parent { get; set; }
         public List<CaDETModifier> Modifiers { get; set; }
-        public List<CaDETMember> Methods { get; set; }
-        public List<CaDETMember> Fields { get; set; }
+        public List<CaDETMember> Members { get; set; }
+        public List<CaDETField> Fields { get; set; }
         public CaDETClassMetrics Metrics { get; set; }
 
-        public CaDETMember FindMethod(string name)
+        public CaDETMember FindMember(string name)
         {
-            return Methods.Find(method => method.Name.Equals(name));
+            return Members.Find(method => method.Name.Equals(name));
+        }
+
+        public CaDETField FindField(string name)
+        {
+            return Fields.Find(field => field.Name.Equals(name));
         }
 
         public bool IsDataClass()
         {
-            double numOfAccessors = Methods.Count(m => m.IsSimpleAccessor());
-            double numOfConstructors = Methods.Count(m => m.Type.Equals(CaDETMemberType.Constructor));
+            double numOfAccessors = Members.Count(m => m.IsSimpleAccessor());
+            double numOfConstructors = Members.Count(m => m.Type.Equals(CaDETMemberType.Constructor));
             double numOfObjectOverrides = CountToStringEqualsHashCode();
             //TODO: Create a more elegant solution for thresholds.
             double dataClassThreshold = 0.9;
 
-            return (numOfAccessors + numOfConstructors + numOfObjectOverrides) / Methods.Count > dataClassThreshold;
+            return (numOfAccessors + numOfConstructors + numOfObjectOverrides) / Members.Count > dataClassThreshold;
         }
 
         private double CountToStringEqualsHashCode()
         {
-            return Methods.Count(m => m.Type.Equals(CaDETMemberType.Method) && (
+            return Members.Count(m => m.Type.Equals(CaDETMemberType.Method) && (
                 m.Name.Contains("tostring", StringComparison.CurrentCultureIgnoreCase) ||
                 m.Name.Contains("equals", StringComparison.CurrentCultureIgnoreCase) ||
                 m.Name.Contains("hashcode", StringComparison.CurrentCultureIgnoreCase)));

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETClass.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETClass.cs
@@ -21,6 +21,11 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
             return Members.Find(method => method.Name.Equals(name));
         }
 
+        public CaDETMember FindMemberBySignature(string signature)
+        {
+            return Members.Find(method => method.GetSignature().Equals(signature));
+        }
+
         public CaDETField FindField(string name)
         {
             return Fields.Find(field => field.Name.Equals(name));

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETField.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETField.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
+{
+    public class CaDETField
+    {
+        public string Name { get; internal set; }
+        public List<CaDETModifier> Modifiers { get; internal set; }
+        public CaDETClass Parent { get; internal set; }
+    }
+}

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETField.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETField.cs
@@ -7,5 +7,16 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
         public string Name { get; internal set; }
         public List<CaDETModifier> Modifiers { get; internal set; }
         public CaDETClass Parent { get; internal set; }
+
+        public override bool Equals(object? other)
+        {
+            if (!(other is CaDETField otherField)) return false;
+            if (Parent == null) return Name.Equals(otherField.Name);
+            return Name.Equals(otherField.Name) && Parent.Equals(otherField.Parent);
+        }
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
@@ -30,13 +30,14 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
             return base.GetHashCode();
         }
 
-        public bool IsSimpleAccessor()
+        public bool IsFieldDefiningAccessor()
         {
             //TODO: This is a workaround that should be reworked https://stackoverflow.com/questions/64009302/roslyn-c-how-to-get-all-fields-and-properties-and-their-belonging-class-acce
             //TODO: It is specific to C# properties. Should move this to CSharpCodeParser so that each language can define its rule for calculating simple accessors.
+            //In its current form, this function will return true for simple properties (e.g., public int SomeNumber { get; set; })
             return Type.Equals(CaDETMemberType.Property)
                    && (InvokedMethods.Count == 0)
-                   && (AccessedAccessors.Count == 0 && AccessedFields.Count < 2)
+                   && (AccessedAccessors.Count == 0 && AccessedFields.Count == 0)
                    && !SourceCode.Contains("return ") && !SourceCode.Contains("=");
         }
     }

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
@@ -25,21 +25,21 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
 
         public string GetSignature()
         {
-            var sb = new StringBuilder();
-            if (Parent != null) sb.Append(Parent.FullName).Append(".");
-            sb.Append(Name);
+            var signatureBuilder = new StringBuilder();
+            if (Parent != null) signatureBuilder.Append(Parent.FullName).Append(".");
+            signatureBuilder.Append(Name);
             if (Params != null)
             {
-                sb.Append("(");
+                signatureBuilder.Append("(");
                 for (var i = 0; i < Params.Count; i++)
                 {
-                    sb.Append(Params[i].Type);
-                    if (i < Params.Count - 1) sb.Append(", ");
+                    signatureBuilder.Append(Params[i].Type);
+                    if (i < Params.Count - 1) signatureBuilder.Append(", ");
                 }
-                sb.Append(")");
+                signatureBuilder.Append(")");
             }
 
-            return sb.ToString();
+            return signatureBuilder.ToString();
         }
 
         public override int GetHashCode()

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
@@ -6,25 +6,24 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
 {
     public class CaDETMember
     {
-        public string Name { get; set; }
-        public CaDETMemberType Type { get; set; }
-        public string SourceCode { get; set; }
-        public CaDETClass Parent { get; set; }
-        public List<string> Params { get; set; }
-        public List<CaDETModifier> Modifiers { get; set; }
-        public ISet<CaDETMember> InvokedMethods { get; set; }
-        public ISet<CaDETMember> AccessedFieldsAndAccessors { get; set; }
-        public CaDETMemberMetrics Metrics { get; set; }
+        public string Name { get; internal set; }
+        public CaDETMemberType Type { get; internal set; }
+        public string SourceCode { get; internal set; }
+        public CaDETClass Parent { get; internal set; }
+        public List<string> Params { get; internal set; }
+        public List<CaDETModifier> Modifiers { get; internal set; }
+        public ISet<CaDETMember> InvokedMethods { get; internal set; }
+        public ISet<CaDETMember> AccessedAccessors { get; internal set; }
+        public ISet<CaDETField> AccessedFields { get; internal set; }
+        public CaDETMemberMetrics Metrics { get; internal set; }
 
         public override bool Equals(object other)
         {
             if (!(other is CaDETMember otherMember)) return false;
             if (Parent == null) return Name.Equals(otherMember.Name);
-            bool nameAndParentEqual = Name.Equals(otherMember.Name) && Parent.Equals(otherMember.Parent);
-            //This is a messy hack. The problem is that this class encapsulates methods/constructors/properties and fields.
-            //Should refactor.
-            if (Type.Equals(CaDETMemberType.Field)) return nameAndParentEqual;
-            return nameAndParentEqual && !Params.Except(otherMember.Params).Any();
+            return Name.Equals(otherMember.Name)
+                   && Parent.Equals(otherMember.Parent)
+                   && !Params.Except(otherMember.Params).Any();
         }
         public override int GetHashCode()
         {
@@ -33,11 +32,12 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
 
         public bool IsSimpleAccessor()
         {
+            //TODO: This is a workaround that should be reworked https://stackoverflow.com/questions/64009302/roslyn-c-how-to-get-all-fields-and-properties-and-their-belonging-class-acce
+            //TODO: It is specific to C# properties. Should move this to CSharpCodeParser so that each language can define its rule for calculating simple accessors.
             return Type.Equals(CaDETMemberType.Property)
-                   && (InvokedMethods == null || InvokedMethods.Count == 0)
-                   && (AccessedFieldsAndAccessors == null || AccessedFieldsAndAccessors.Count == 0)
-                   && !SourceCode.Contains("return ") && !SourceCode.Contains("="); //TODO: This is a workaround that should be reworked https://stackoverflow.com/questions/64009302/roslyn-c-how-to-get-all-fields-and-properties-and-their-belonging-class-acce
-                                                                                    //TODO: It is specific to C# properties. Should move this to CSharpCodeParser so that each language can define its rule for calculating simple accessors.
+                   && (InvokedMethods.Count == 0)
+                   && (AccessedAccessors.Count == 0 && AccessedFields.Count < 2)
+                   && !SourceCode.Contains("return ") && !SourceCode.Contains("=");
         }
     }
 }

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using RepositoryCompiler.CodeModel.CaDETModel.Metrics;
+﻿using RepositoryCompiler.CodeModel.CaDETModel.Metrics;
+using System.Collections.Generic;
+using System.Text;
 
 namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
 {
@@ -10,7 +10,7 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
         public CaDETMemberType Type { get; internal set; }
         public string SourceCode { get; internal set; }
         public CaDETClass Parent { get; internal set; }
-        public List<string> Params { get; internal set; }
+        public List<CaDETParameter> Params { get; internal set; }
         public List<CaDETModifier> Modifiers { get; internal set; }
         public ISet<CaDETMember> InvokedMethods { get; internal set; }
         public ISet<CaDETMember> AccessedAccessors { get; internal set; }
@@ -20,15 +20,32 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
         public override bool Equals(object other)
         {
             if (!(other is CaDETMember otherMember)) return false;
-            if (Parent == null) return Name.Equals(otherMember.Name);
-            return Name.Equals(otherMember.Name)
-                   && Parent.Equals(otherMember.Parent)
-                   && !Params.Except(otherMember.Params).Any();
+            return Parent.Equals(otherMember.Parent) && GetSignature().Equals(otherMember.GetSignature());
         }
+
+        public string GetSignature()
+        {
+            var sb = new StringBuilder();
+            sb.Append(Name);
+            if (Params != null)
+            {
+                sb.Append("(");
+                for (var i = 0; i < Params.Count; i++)
+                {
+                    sb.Append(Params[i].Type);
+                    if (i < Params.Count - 1) sb.Append(", ");
+                }
+                sb.Append(")");
+            }
+
+            return sb.ToString();
+        }
+
         public override int GetHashCode()
         {
             return base.GetHashCode();
         }
+
 
         public bool IsFieldDefiningAccessor()
         {

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMember.cs
@@ -12,10 +12,10 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
         public CaDETClass Parent { get; internal set; }
         public List<CaDETParameter> Params { get; internal set; }
         public List<CaDETModifier> Modifiers { get; internal set; }
+        public CaDETMemberMetrics Metrics { get; internal set; }
         public ISet<CaDETMember> InvokedMethods { get; internal set; }
         public ISet<CaDETMember> AccessedAccessors { get; internal set; }
         public ISet<CaDETField> AccessedFields { get; internal set; }
-        public CaDETMemberMetrics Metrics { get; internal set; }
 
         public override bool Equals(object other)
         {
@@ -26,6 +26,7 @@ namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
         public string GetSignature()
         {
             var sb = new StringBuilder();
+            if (Parent != null) sb.Append(Parent.FullName).Append(".");
             sb.Append(Name);
             if (Params != null)
             {

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMemberType.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETMemberType.cs
@@ -4,7 +4,6 @@
     {
         Method,
         Property,
-        Constructor,
-        Field
+        Constructor
     }
 }

--- a/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETParameter.cs
+++ b/RepositoryCompiler/CodeModel/CaDETModel/CodeItems/CaDETParameter.cs
@@ -1,0 +1,8 @@
+﻿namespace RepositoryCompiler.CodeModel.CaDETModel.CodeItems
+{
+    public class CaDETParameter
+    {
+        public string Name { get; internal set; }
+        public string Type { get; internal set; }
+    }
+}

--- a/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpCaDETMemberBuilder.cs
+++ b/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpCaDETMemberBuilder.cs
@@ -1,0 +1,132 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using RepositoryCompiler.CodeModel.CaDETModel.CodeItems;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
+{
+    internal class CSharpCaDETMemberBuilder
+    {
+
+        private const string _separator = ".";
+
+        private readonly MemberDeclarationSyntax _cSharpMember;
+        private readonly SemanticModel _semanticModel;
+        private CaDETMember _member;
+
+        internal CSharpCaDETMemberBuilder(MemberDeclarationSyntax cSharpMember, SemanticModel semanticModel)
+        {
+            _member = CreateMemberBasedOnType(cSharpMember);
+            if (_member == null) throw new InappropriateMemberTypeException();
+            _cSharpMember = cSharpMember;
+            _semanticModel = semanticModel;
+        }
+
+        internal CaDETMember CreateBasicMember(CaDETClass parent)
+        {
+            _member.Modifiers = _cSharpMember.Modifiers.Select(modifier => new CaDETModifier(modifier.ValueText)).ToList();
+            _member.SourceCode = _cSharpMember.ToString();
+            _member.Parent = parent;
+            _member.Params = GetMethodParams();
+            return _member;
+        }
+
+        internal void DetermineAccessedCodeItems(List<CaDETClass> allProjectClasses)
+        {
+            _member.InvokedMethods = CalculateInvokedMethods(allProjectClasses);
+            _member.AccessedAccessors = CalculateAccessedAccessors(allProjectClasses);
+            _member.AccessedFields = CalculateAccessedFields(allProjectClasses);
+        }
+
+        internal void CalculateMetrics(CSharpMetricCalculator calculator)
+        {
+            _member.Metrics = calculator.CalculateMemberMetrics(_cSharpMember, _member);
+        }
+
+        private CaDETMember CreateMemberBasedOnType(MemberDeclarationSyntax member)
+        {
+            return member switch
+            {
+                PropertyDeclarationSyntax property => new CaDETMember { Type = CaDETMemberType.Property, Name = property.Identifier.Text },
+                ConstructorDeclarationSyntax constructor => new CaDETMember { Type = CaDETMemberType.Constructor, Name = constructor.Identifier.Text },
+                MethodDeclarationSyntax method => new CaDETMember { Type = CaDETMemberType.Method, Name = method.Identifier.Text },
+                _ => null
+            };
+        }
+        private List<CaDETParameter> GetMethodParams()
+        {
+            List<CaDETParameter> memberParams = new List<CaDETParameter>();
+            var paramLists = _cSharpMember.DescendantNodes().OfType<ParameterListSyntax>().ToList();
+            if (!paramLists.Any()) return memberParams;
+
+            // First() below gives the function param list. Other elements of the list include params for inline lambda expressions
+            var parameters = paramLists.First().Parameters;
+            foreach (var parameter in parameters)
+            {
+                var symbol = _semanticModel.GetDeclaredSymbol(parameter);
+                memberParams.Add(new CaDETParameter { Name = symbol.Name, Type = symbol.ToDisplayString() });
+            }
+
+            return memberParams;
+        }
+
+        private ISet<CaDETMember> CalculateInvokedMethods(List<CaDETClass> allProjectClasses)
+        {
+            ISet<CaDETMember> methods = new HashSet<CaDETMember>();
+            var invokedMethods = _cSharpMember.DescendantNodes().OfType<InvocationExpressionSyntax>();
+            foreach (var invoked in invokedMethods)
+            {
+                var symbol = _semanticModel.GetSymbolInfo(invoked.Expression).Symbol;
+                if (symbol == null) continue; //True when invoked method is a system or library call and not part of our code.
+                foreach (var projectClass in allProjectClasses)
+                {
+                    var invokedCaDETMember = projectClass.FindMemberBySignature(symbol.ToDisplayString());
+                    if (invokedCaDETMember == null) continue;
+                    methods.Add(invokedCaDETMember);
+                    break;
+                }
+            }
+
+            return methods;
+        }
+        
+        private ISet<CaDETField> CalculateAccessedFields(List<CaDETClass> allProjectClasses)
+        {
+            ISet<CaDETField> fields = new HashSet<CaDETField>();
+            var accessedFields = _semanticModel.GetOperation(_cSharpMember).Descendants().OfType<IFieldReferenceOperation>();
+            foreach (var field in accessedFields)
+            {
+                var fullFieldName = field.Member.ToDisplayString();
+                var containingClass = FindContainingClass(allProjectClasses, fullFieldName);
+                fields.Add(containingClass.FindField(fullFieldName.Split(_separator).Last()));
+            }
+            return fields;
+        }
+
+        private ISet<CaDETMember> CalculateAccessedAccessors(List<CaDETClass> allProjectClasses)
+        {
+            ISet<CaDETMember> accessors = new HashSet<CaDETMember>();
+            var accessedAccessors = _semanticModel.GetOperation(_cSharpMember).Descendants().OfType<IPropertyReferenceOperation>();
+            foreach (var accessor in accessedAccessors)
+            {
+                foreach (var projectClass in allProjectClasses)
+                {
+                    var accessedCaDETMember = projectClass.FindMemberBySignature(accessor.Member.ToDisplayString() + "()");
+                    if (accessedCaDETMember == null) continue;
+                    accessors.Add(accessedCaDETMember);
+                    break;
+                }
+            }
+            return accessors;
+        }
+        private CaDETClass FindContainingClass(List<CaDETClass> classes, string stubElementName)
+        {
+            string[] nameParts = stubElementName.Split(_separator);
+            string className = string.Join(_separator, nameParts, 0, nameParts.Length - 1);
+            return classes.Find(c => c.FullName.Equals(className));
+        }
+    }
+}

--- a/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpCaDETMemberBuilder.cs
+++ b/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpCaDETMemberBuilder.cs
@@ -15,7 +15,7 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
 
         private readonly MemberDeclarationSyntax _cSharpMember;
         private readonly SemanticModel _semanticModel;
-        private CaDETMember _member;
+        private readonly CaDETMember _member;
 
         internal CSharpCaDETMemberBuilder(MemberDeclarationSyntax cSharpMember, SemanticModel semanticModel)
         {
@@ -101,9 +101,22 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
             {
                 var fullFieldName = field.Member.ToDisplayString();
                 var containingClass = FindContainingClass(allProjectClasses, fullFieldName);
+                if(IsEnumeration(containingClass)) continue;
                 fields.Add(containingClass.FindField(fullFieldName.Split(_separator).Last()));
             }
             return fields;
+        }
+
+        private CaDETClass FindContainingClass(List<CaDETClass> classes, string stubElementName)
+        {
+            string[] nameParts = stubElementName.Split(_separator);
+            string className = string.Join(_separator, nameParts, 0, nameParts.Length - 1);
+            return classes.Find(c => c.FullName.Equals(className));
+        }
+
+        private static bool IsEnumeration(CaDETClass containingClass)
+        {
+            return containingClass == null;
         }
 
         private ISet<CaDETMember> CalculateAccessedAccessors(List<CaDETClass> allProjectClasses)
@@ -121,12 +134,6 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
                 }
             }
             return accessors;
-        }
-        private CaDETClass FindContainingClass(List<CaDETClass> classes, string stubElementName)
-        {
-            string[] nameParts = stubElementName.Split(_separator);
-            string className = string.Join(_separator, nameParts, 0, nameParts.Length - 1);
-            return classes.Find(c => c.FullName.Equals(className));
         }
     }
 }

--- a/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpCodeParser.cs
+++ b/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpCodeParser.cs
@@ -63,7 +63,7 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
                 SourceCode = node.ToString()
             };
             parsedClass.Modifiers = GetModifiers(node);
-            parsedClass.Parent = new CaDETClass {Name = symbol.BaseType.ToString()};
+            parsedClass.Parent = new CaDETClass { Name = symbol.BaseType.ToString() };
             parsedClass.Fields = ParseFields(node.Members, parsedClass);
             parsedClass.Members = ParseMethodsAndCalculateMetrics(node.Members, parsedClass, semanticModel);
 
@@ -218,12 +218,7 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
         private CaDETClass LinkParent(List<CaDETClass> classes, CaDETClass parent)
         {
             if (parent.Name.Equals("object")) return null;
-            foreach (var c in classes)
-            {
-                if (c.FullName.Equals(parent.Name)) return c;
-            }
-
-            return null;
+            return classes.FirstOrDefault(c => c.FullName.Equals(parent.Name));
         }
 
         private ISet<CaDETMember> LinkInvokedMembers(List<CaDETClass> classes, ISet<CaDETMember> stubMembers)
@@ -231,10 +226,10 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
             ISet<CaDETMember> linkedMembers = new HashSet<CaDETMember>();
             foreach (var member in stubMembers)
             {
-                var linkingClass = FindParentClass(classes, member.Name);
-                if(IsEnumeration(linkingClass)) continue;
+                var containingClass = FindContainingClass(classes, member.Name);
+                if(IsEnumeration(containingClass)) continue;
                 string memberName = member.Name.Split(_separator).Last();
-                var linkedMember = linkingClass.FindMember(memberName);
+                var linkedMember = containingClass.FindMember(memberName);
                 if (linkedMember != null) linkedMembers.Add(linkedMember);
             }
 
@@ -246,17 +241,17 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
             ISet<CaDETField> linkedFields = new HashSet<CaDETField>();
             foreach (var field in stubFields)
             {
-                var linkingClass = FindParentClass(classes, field.Name);
-                if (IsEnumeration(linkingClass)) continue;
+                var containingClass = FindContainingClass(classes, field.Name);
+                if (IsEnumeration(containingClass)) continue;
                 string fieldName = field.Name.Split(_separator).Last();
-                var linkedField = linkingClass.FindField(fieldName);
+                var linkedField = containingClass.FindField(fieldName);
                 if (linkedField != null) linkedFields.Add(linkedField);
             }
 
             return linkedFields;
         }
 
-        private CaDETClass FindParentClass(List<CaDETClass> classes, string stubElementName)
+        private CaDETClass FindContainingClass(List<CaDETClass> classes, string stubElementName)
         {
             string[] nameParts = stubElementName.Split(_separator);
             string className = string.Join(_separator, nameParts, 0, nameParts.Length - 1);

--- a/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpCodeParser.cs
+++ b/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpCodeParser.cs
@@ -24,13 +24,13 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
 
         public List<CaDETClass> GetParsedClasses(IEnumerable<string> sourceCode)
         {
-            ParseSyntaxTrees(sourceCode);
+            LoadSyntaxTrees(sourceCode);
             var parsedClasses = ParseClasses();
             var linkedClasses = ConnectCaDETGraph(parsedClasses);
             return CalculateMetrics(linkedClasses);
         }
 
-        private void ParseSyntaxTrees(IEnumerable<string> sourceCode)
+        private void LoadSyntaxTrees(IEnumerable<string> sourceCode)
         {
             foreach (var code in sourceCode)
             {

--- a/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpMetricCalculator.cs
+++ b/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpMetricCalculator.cs
@@ -29,7 +29,7 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
             if (maxCohesion == 0) return null;
 
             double methodFieldAccess = 0;
-            foreach (var method in parsedClass.Methods.Where(method => method.Type.Equals(CaDETMemberType.Method)))
+            foreach (var method in parsedClass.Members.Where(method => method.Type.Equals(CaDETMemberType.Method)))
             {
                 methodFieldAccess += CountOwnFieldAndAccessorAccessed(parsedClass, method);
             }
@@ -38,19 +38,13 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
 
         private int GetNumberOfSimpleAccessors(CaDETClass parsedClass)
         {
-            return parsedClass.Methods.Count(method => method.IsSimpleAccessor());
+            return parsedClass.Members.Count(method => method.IsSimpleAccessor());
         }
 
         private int CountOwnFieldAndAccessorAccessed(CaDETClass parsedClass, CaDETMember method)
         {
-            int counter = 0;
-            foreach (var fieldOrAccessor in method.AccessedFieldsAndAccessors)
-            {
-                if (Enumerable.Contains(parsedClass.Fields, fieldOrAccessor) || Enumerable.Contains(parsedClass.Methods, fieldOrAccessor))
-                {
-                    counter++;
-                }
-            }
+            int counter = method.AccessedFields.Count(field => Enumerable.Contains(parsedClass.Fields, field));
+            counter += method.AccessedAccessors.Count(accessor => Enumerable.Contains(parsedClass.Members, accessor));
 
             return counter;
         }
@@ -58,7 +52,7 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
         private int GetWeightedMethodPerClass(CaDETClass parsedClass)
         {
             //Defined based on 10.1109/32.295895
-            return parsedClass.Methods.Sum(method => method.Metrics.CYCLO);
+            return parsedClass.Members.Sum(method => method.Metrics.CYCLO);
         }
         
         private int GetNumberOfAttributesDefined(CaDETClass parsedClass)
@@ -70,7 +64,7 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
 
         private int GetNumberOfMethodsDeclared(CaDETClass parsedClass)
         {
-            return parsedClass.Methods.Count(method => method.Type.Equals(CaDETMemberType.Method));
+            return parsedClass.Members.Count(method => method.Type.Equals(CaDETMemberType.Method));
         }
 
         public CaDETMemberMetrics CalculateMemberMetrics(MemberDeclarationSyntax member, CaDETMember method)

--- a/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpMetricCalculator.cs
+++ b/RepositoryCompiler/CodeModel/CodeParsers/CSharp/CSharpMetricCalculator.cs
@@ -25,7 +25,7 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
         private double? GetLackOfCohesionOfMethods(CaDETClass parsedClass)
         {
             //TODO: Will need to reexamine the way we look at accessors and fields
-            double maxCohesion = (GetNumberOfAttributesDefined(parsedClass) + GetNumberOfSimpleAccessors(parsedClass)) * GetNumberOfMethodsDeclared(parsedClass);
+            double maxCohesion = (GetNumberOfAttributesDefined(parsedClass) + CountFieldDefiningAccessors(parsedClass)) * GetNumberOfMethodsDeclared(parsedClass);
             if (maxCohesion == 0) return null;
 
             double methodFieldAccess = 0;
@@ -36,9 +36,9 @@ namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
             return Math.Round(1 - methodFieldAccess/maxCohesion, 3);
         }
 
-        private int GetNumberOfSimpleAccessors(CaDETClass parsedClass)
+        private int CountFieldDefiningAccessors(CaDETClass parsedClass)
         {
-            return parsedClass.Members.Count(method => method.IsSimpleAccessor());
+            return parsedClass.Members.Count(method => method.IsFieldDefiningAccessor());
         }
 
         private int CountOwnFieldAndAccessorAccessed(CaDETClass parsedClass, CaDETMember method)

--- a/RepositoryCompiler/CodeModel/CodeParsers/CSharp/InappropriateMemberTypeException.cs
+++ b/RepositoryCompiler/CodeModel/CodeParsers/CSharp/InappropriateMemberTypeException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace RepositoryCompiler.CodeModel.CodeParsers.CSharp
+{
+    [Serializable]
+    internal class InappropriateMemberTypeException : Exception
+    {
+        public InappropriateMemberTypeException()
+        {
+        }
+
+        public InappropriateMemberTypeException(string message) : base(message)
+        {
+        }
+
+        public InappropriateMemberTypeException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected InappropriateMemberTypeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/RepositoryCompilerTests/Integration/CaDETModelBuilderTests.cs
+++ b/RepositoryCompilerTests/Integration/CaDETModelBuilderTests.cs
@@ -20,8 +20,8 @@ namespace RepositoryCompilerTests.Integration
             conflict.Fields.ShouldContain(f => f.Name.Equals("ancestor"));
             conflict.Fields.ShouldContain(f => f.Name.Equals("ours"));
             conflict.Fields.ShouldContain(f => f.Name.Equals("theirs"));
-            conflict.Methods.ShouldContain(m => m.Name.Equals("Conflict") && m.Type.Equals(CaDETMemberType.Constructor) && m.AccessedFieldsAndAccessors.Count == 3);
-            conflict.Methods.ShouldContain(m => m.Name.Equals("Equals") && m.Type.Equals(CaDETMemberType.Method) && m.AccessedFieldsAndAccessors.Count == 1);
+            conflict.Members.ShouldContain(m => m.Name.Equals("Conflict") && m.Type.Equals(CaDETMemberType.Constructor) && m.AccessedFields.Count == 3);
+            conflict.Members.ShouldContain(m => m.Name.Equals("Equals") && m.Type.Equals(CaDETMemberType.Method) && m.AccessedFields.Count == 1);
             conflict.Metrics.LOC.ShouldBe(108);
             conflict.Metrics.LCOM.ShouldBe(0.833);
             conflict.Metrics.NAD.ShouldBe(4);
@@ -29,7 +29,7 @@ namespace RepositoryCompilerTests.Integration
             conflict.Metrics.WMC.ShouldBe(8);
             CaDETClass certificate = project.Classes.Find(c => c.FullName.Equals("LibGit2Sharp.Certificate"));
             certificate.ShouldNotBeNull();
-            certificate.Methods.ShouldBeEmpty();
+            certificate.Members.ShouldBeEmpty();
             certificate.Fields.ShouldBeEmpty();
             certificate.Metrics.LCOM.ShouldBeNull();
             certificate.Metrics.LOC.ShouldBe(3);
@@ -39,9 +39,9 @@ namespace RepositoryCompilerTests.Integration
             CaDETClass handles = project.Classes.Find(c => c.FullName.Equals("LibGit2Sharp.Core.Handles.Libgit2Object"));
             handles.ShouldNotBeNull();
             handles.Fields.ShouldContain(f => f.Name.Equals("ptr"));
-            handles.Methods.ShouldContain(m => m.Name.Equals("Handle") && m.Type.Equals(CaDETMemberType.Property));
-            handles.Methods.ShouldContain(m => m.Name.Equals("Dispose") && m.Type.Equals(CaDETMemberType.Method)
-                                                                        && m.InvokedMethods.Count == 1 && m.AccessedFieldsAndAccessors.Count == 0);
+            handles.Members.ShouldContain(m => m.Name.Equals("Handle") && m.Type.Equals(CaDETMemberType.Property));
+            handles.Members.ShouldContain(m => m.Name.Equals("Dispose") && m.Type.Equals(CaDETMemberType.Method)
+                                                                        && m.InvokedMethods.Count == 1 && m.AccessedFields.Count == 0 && m.AccessedAccessors.Count == 0);
             handles.Metrics.LCOM.ShouldBe(0.667);
             handles.Metrics.LOC.ShouldBe(100);
             handles.Metrics.NAD.ShouldBe(3);

--- a/RepositoryCompilerTests/Unit/CaDETCodeModelTests.cs
+++ b/RepositoryCompilerTests/Unit/CaDETCodeModelTests.cs
@@ -24,14 +24,14 @@ namespace RepositoryCompilerTests.Unit
             var doctorClass = classes.First();
             doctorClass.Metrics.NAD.ShouldBe(0);
             doctorClass.Metrics.NMD.ShouldBe(1);
-            doctorClass.Methods.ShouldContain(method =>
+            doctorClass.Members.ShouldContain(method =>
                 method.Type.Equals(CaDETMemberType.Property) && method.Name.Equals("Email"));
-            doctorClass.Methods.ShouldContain(method => method.Type.Equals(CaDETMemberType.Constructor));
-            doctorClass.Methods.ShouldContain(method =>
+            doctorClass.Members.ShouldContain(method => method.Type.Equals(CaDETMemberType.Constructor));
+            doctorClass.Members.ShouldContain(method =>
                 method.Type.Equals(CaDETMemberType.Method) && method.Name.Equals("IsAvailable"));
-            doctorClass.Methods.First().Parent.SourceCode.ShouldBe(doctorClass.SourceCode);
-            doctorClass.FindMethod("Email").Modifiers.First().Value.ShouldBe(CaDETModifierValue.Public);
-            doctorClass.FindMethod("IsAvailable").Modifiers.First().Value.ShouldBe(CaDETModifierValue.Internal);
+            doctorClass.Members.First().Parent.SourceCode.ShouldBe(doctorClass.SourceCode);
+            doctorClass.FindMember("Email").Modifiers.First().Value.ShouldBe(CaDETModifierValue.Public);
+            doctorClass.FindMember("IsAvailable").Modifiers.First().Value.ShouldBe(CaDETModifierValue.Internal);
         }
 
         [Fact]
@@ -43,8 +43,8 @@ namespace RepositoryCompilerTests.Unit
 
             var doctorClass = classes.First();
             doctorClass.Metrics.LOC.ShouldBe(22);
-            doctorClass.FindMethod("Email").Metrics.LOC.ShouldBe(1);
-            doctorClass.FindMethod("IsAvailable").Metrics.LOC.ShouldBe(8);
+            doctorClass.FindMember("Email").Metrics.LOC.ShouldBe(1);
+            doctorClass.FindMember("IsAvailable").Metrics.LOC.ShouldBe(8);
         }
 
         [Fact]
@@ -56,8 +56,8 @@ namespace RepositoryCompilerTests.Unit
 
             var gitClass = classes.First();
 
-            gitClass.FindMethod("CheckoutCommit").Metrics.CYCLO.ShouldBe(2);
-            gitClass.FindMethod("ParseDocuments").Metrics.CYCLO.ShouldBe(4);
+            gitClass.FindMember("CheckoutCommit").Metrics.CYCLO.ShouldBe(2);
+            gitClass.FindMember("ParseDocuments").Metrics.CYCLO.ShouldBe(4);
         }
 
         [Fact]
@@ -80,9 +80,9 @@ namespace RepositoryCompilerTests.Unit
 
             var dateRange = classes.Find(c => c.Name.Equals("DateRange"));
             var service = classes.Find(c => c.Name.Equals("DoctorService"));
-            var overlapsWith = dateRange.FindMethod("OverlapsWith");
-            var logChecked = service.FindMethod("LogChecked");
-            var findDoctors = service.FindMethod("FindAvailableDoctor");
+            var overlapsWith = dateRange.FindMember("OverlapsWith");
+            var logChecked = service.FindMember("LogChecked");
+            var findDoctors = service.FindMember("FindAvailableDoctor");
             findDoctors.InvokedMethods.ShouldContain(overlapsWith);
             findDoctors.InvokedMethods.ShouldContain(logChecked);
         }
@@ -96,10 +96,10 @@ namespace RepositoryCompilerTests.Unit
 
             var doctor = classes.Find(c => c.Name.Equals("Doctor"));
             var service = classes.Find(c => c.Name.Equals("DoctorService"));
-            var holidayDates = doctor.FindMethod("HolidayDates");
-            var findDoctors = service.FindMethod("FindAvailableDoctor");
-            findDoctors.AccessedFieldsAndAccessors.ShouldContain(holidayDates);
-            findDoctors.AccessedFieldsAndAccessors.ShouldContain(doctor.Fields.Find(f => f.Name.Equals("Test")));
+            var holidayDates = doctor.FindMember("HolidayDates");
+            var findDoctors = service.FindMember("FindAvailableDoctor");
+            findDoctors.AccessedAccessors.ShouldContain(holidayDates);
+            findDoctors.AccessedFields.ShouldContain(doctor.Fields.Find(f => f.Name.Equals("Test")));
         }
 
         [Fact]
@@ -137,10 +137,10 @@ namespace RepositoryCompilerTests.Unit
             List<CaDETClass> classes = builder.BuildCodeModel(_testDataFactory.GetGitAdapterClassText());
 
             var gitClass = classes.First();
-            gitClass.FindMethod("CheckForNewCommits").Metrics.NOP.ShouldBe(0);
-            gitClass.FindMethod("PullChanges").Metrics.NOP.ShouldBe(0);
-            gitClass.FindMethod("GetCommits").Metrics.NOP.ShouldBe(1);
-            gitClass.FindMethod("CheckoutCommit").Metrics.NOP.ShouldBe(1);
+            gitClass.FindMember("CheckForNewCommits").Metrics.NOP.ShouldBe(0);
+            gitClass.FindMember("PullChanges").Metrics.NOP.ShouldBe(0);
+            gitClass.FindMember("GetCommits").Metrics.NOP.ShouldBe(1);
+            gitClass.FindMember("CheckoutCommit").Metrics.NOP.ShouldBe(1);
         }
 
         [Fact]
@@ -151,8 +151,8 @@ namespace RepositoryCompilerTests.Unit
             List<CaDETClass> classes = builder.BuildCodeModel(_testDataFactory.GetGitAdapterClassText());
 
             var gitClass = classes.First();
-            gitClass.FindMethod("CheckForNewCommits").Metrics.NOLV.ShouldBe(2);
-            gitClass.FindMethod("GetActiveCommit").Metrics.NOLV.ShouldBe(0);
+            gitClass.FindMember("CheckForNewCommits").Metrics.NOLV.ShouldBe(2);
+            gitClass.FindMember("GetActiveCommit").Metrics.NOLV.ShouldBe(0);
         }
 
 
@@ -170,8 +170,8 @@ namespace RepositoryCompilerTests.Unit
             doctor.Parent.ShouldBe(employee);
             employee.Parent.ShouldBe(entity);
             entity.Parent.ShouldBeNull();
-            doctor.FindMethod("Doctor").AccessedFieldsAndAccessors.ShouldContain(employee.FindMethod("Email"));
-            employee.FindMethod("Employee").AccessedFieldsAndAccessors.ShouldContain(entity.FindMethod("Id"));
+            doctor.FindMember("Doctor").AccessedAccessors.ShouldContain(employee.FindMember("Email"));
+            employee.FindMember("Employee").AccessedAccessors.ShouldContain(entity.FindMember("Id"));
         }
     }
 }

--- a/RepositoryCompilerTests/Unit/CaDETCodeModelTests.cs
+++ b/RepositoryCompilerTests/Unit/CaDETCodeModelTests.cs
@@ -155,8 +155,6 @@ namespace RepositoryCompilerTests.Unit
             gitClass.FindMember("GetActiveCommit").Metrics.NOLV.ShouldBe(0);
         }
 
-
-
         [Fact]
         public void Establishes_correct_class_hierarchy()
         {

--- a/RepositoryCompilerTests/Unit/CaDETCodeModelTests.cs
+++ b/RepositoryCompilerTests/Unit/CaDETCodeModelTests.cs
@@ -88,6 +88,24 @@ namespace RepositoryCompilerTests.Unit
         }
 
         [Fact]
+        public void Checks_method_signature()
+        {
+            CodeModelBuilder builder = new CodeModelBuilder(LanguageEnum.CSharp);
+
+            List<CaDETClass> classes = builder.BuildCodeModel(_testDataFactory.GetMultipleClassTexts());
+
+            var doctor = classes.Find(c => c.Name.Equals("Doctor"));
+            var dateRange = classes.Find(c => c.Name.Equals("DateRange"));
+            var service = classes.Find(c => c.Name.Equals("DoctorService"));
+            var holidayDates = doctor.FindMember("HolidayDates");
+            var overlapsWith = dateRange.FindMember("OverlapsWith");
+            var findDoctors = service.FindMember("FindAvailableDoctor");
+            holidayDates.GetSignature().Equals("HolidayDates");
+            overlapsWith.GetSignature().Equals("OverlapsWith(DoctorApp.Model.Data.DateR.DateRange)");
+            findDoctors.GetSignature().Equals("FindAvailableDoctor(DoctorApp.Model.Data.DateR.DateRange)");
+        }
+
+        [Fact]
         public void Calculates_accessed_fields()
         {
             CodeModelBuilder builder = new CodeModelBuilder(LanguageEnum.CSharp);
@@ -127,6 +145,26 @@ namespace RepositoryCompilerTests.Unit
             dateRange.IsDataClass().ShouldBeFalse();
             doctor.IsDataClass().ShouldBeTrue();
             service.IsDataClass().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Builds_member_parameters()
+        {
+            CodeModelBuilder builder = new CodeModelBuilder(LanguageEnum.CSharp);
+
+            List<CaDETClass> classes = builder.BuildCodeModel(_testDataFactory.GetMultipleClassTexts());
+
+            var service = classes.Find(c => c.Name.Equals("DoctorService"));
+            var dateRange = classes.Find(c => c.Name.Equals("DateRange"));
+            var overlapTimeSpanParam = dateRange.FindMember("OverlapsWith").Params.First();
+            overlapTimeSpanParam.Name.ShouldBe("timeSpan");
+            overlapTimeSpanParam.Type.ShouldBe("DoctorApp.Model.Data.DateR.DateRange");
+            var serviceTimeSpanParam = service.FindMember("FindAvailableDoctor").Params.First();
+            serviceTimeSpanParam.Name.ShouldBe("timeSpan");
+            serviceTimeSpanParam.Type.ShouldBe("DoctorApp.Model.Data.DateR.DateRange");
+            var logParam = service.FindMember("LogChecked").Params.First();
+            logParam.Name.ShouldBe("testData");
+            logParam.Type.ShouldBe("int");
         }
 
         [Fact]

--- a/RepositoryCompilerTests/Unit/CodeModelTestDataFactory.cs
+++ b/RepositoryCompilerTests/Unit/CodeModelTestDataFactory.cs
@@ -229,9 +229,9 @@ namespace RepositoryCompilerTests.Unit
                         }
                         return null;
                     }
-                    private void LogChecked()
+                    private int LogChecked(int testData)
                     {
-                        return;
+                        return testData;
                     }
                 }
             }"

--- a/RepositoryCompilerTests/Unit/CodeModelTestDataFactory.cs
+++ b/RepositoryCompilerTests/Unit/CodeModelTestDataFactory.cs
@@ -224,7 +224,7 @@ namespace RepositoryCompilerTests.Unit
                             {
                                 d.Test = null;
                                 if (!holiday.OverlapsWith(timeSpan)) return d;
-                                LogChecked();
+                                LogChecked(33);
                             }
                         }
                         return null;


### PR DESCRIPTION
This is a major change that should break some of your code from the active PRs.

The additions include:
- Defining a CaDETMemberParamter class that encapsulates the name and type.
- Extracting a CaDETField as a standalone type from the current CaDETMember.
- Adding the CSharpCaDETMemberTransformer to split the logic of the CSharpCodeParser.

Please review the code, leave any comments for mysterious names or stuff that is hard for you to understand so that I can enhance it further.